### PR TITLE
Fixed bug ignoring sampling args in Simple Env, Added </answer> as stop sequence for Math Env

### DIFF
--- a/verifiers/envs/math_env.py
+++ b/verifiers/envs/math_env.py
@@ -15,7 +15,18 @@ class MathEnv(SimpleEnv):
                  few_shot: List[Dict[str, str]] = MATH_FEW_SHOT[0],
                  fields: List[str | Tuple[str, ...]] = ["reasoning", "answer"],
                  **kwargs):
-        super().__init__(system_prompt=system_prompt, few_shot=few_shot, **kwargs)
+        sampling_args = {
+            "skip_special_tokens": False,
+            "spaces_between_special_tokens": False,
+            "stop": ["</answer>"],
+            "include_stop_str_in_output": True,
+        }
+        super().__init__(
+            system_prompt=system_prompt,
+            few_shot=few_shot,
+            sampling_args=sampling_args,
+            **kwargs,
+        )
         self.parser = XMLParser(fields=fields)
         self.dataset_name = dataset
         self.dataset = preprocess_dataset(

--- a/verifiers/envs/simple_env.py
+++ b/verifiers/envs/simple_env.py
@@ -14,10 +14,11 @@ class SimpleEnv(BaseEnv):
                  sampling_args: Dict[str, Any] = {},
                  **kwargs):
         super().__init__(**kwargs)
-        sampling_args = {
+        default_args = {
             "skip_special_tokens": False,
             "spaces_between_special_tokens": False,
         }
+        default_args.update(sampling_args)
         self.system_prompt = system_prompt
         self.few_shot = few_shot
         self.sampling_args = sampling_args


### PR DESCRIPTION
I think the Math Env thing should be a default, made training run take a lot longer and model consistently outputted gibberish (like some REAL weird shit sometimes) after the </answer> . 

Also, we can't override sampling args in simple env because it was just overwriting them before. so this should fix that .