### PR TITLE
add reward_weights support to rubrics

### DIFF
--- a/verifiers/examples/gsm8k_doublecheck.py
+++ b/verifiers/examples/gsm8k_doublecheck.py
@@ -8,7 +8,7 @@ dataset = vf_env.get_dataset()
 rubric = vf_env.get_rubric()
 
 run_name = "gsm8k-dc_" + model_name.split("/")[-1].lower()
-training_args = vf.get_default_grpo_config(run_name=run_name, num_gpus=8)
+training_args = vf.get_default_grpo_config(run_name=run_name, num_gpus=8, reward_weights=vf_env.rubric.get_reward_weights())
 trainer = vf.GRPOEnvTrainer(
     model=model,
     processing_class=tokenizer,

--- a/verifiers/rubrics/rubric.py
+++ b/verifiers/rubrics/rubric.py
@@ -15,6 +15,7 @@ class Rubric(ABC):
         for key, value in kwargs.items():
             setattr(self, key, value)
         self.reward_funcs = []
+        self.reward_weights = None
 
     def get_assistant_messages(self, trajectory: List[Dict[str, str]]) -> List[Dict[str, str]]:
         """Helper function to extract assistant messages from a trajectory."""
@@ -44,5 +45,5 @@ class Rubric(ABC):
     def get_reward_funcs(self) -> List[RewardFunc]:
         return self.reward_funcs
 
-
-
+    def get_reward_weights(self) -> List[float] | None:
+        return self.reward_weights

--- a/verifiers/utils/config_utils.py
+++ b/verifiers/utils/config_utils.py
@@ -1,7 +1,9 @@
 from trl import GRPOConfig
+from typing import List, Optional
 
 def get_default_grpo_config(run_name: str,
-                            num_gpus: int = 1) -> GRPOConfig:
+                            num_gpus: int = 1,
+                            reward_weights: Optional[List[float]] = None) -> GRPOConfig:
     return GRPOConfig(
         output_dir=f"outputs/{run_name}",
         run_name=run_name,
@@ -31,6 +33,7 @@ def get_default_grpo_config(run_name: str,
         log_on_each_node=False,
         log_completions=True,
         report_to="wandb",
+        reward_weights=reward_weights
     )
 
 


### PR DESCRIPTION
Hello, wanted to set different weights for each of the reward functions and didn't see a nice and clean way to do it. This PR has a minimally invasive implementation where you can attach it to the rubric and then use the rubric to pass it into the `get_default_grpo_config` function.

Aimed to not break existing stuff, but I feel like a cleaner option later down the line might be to just have the envs have `get_reward_funcs` and `get_reward_weights` functions, or maybe a single `get_rubric` that returns a dict with `"funcs"` and `"weights"` keys?