### PR TITLE
GSM8K should use CALCULATOR_FEW_SHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ Tested with Python 3.11 and this [image](https://hub.docker.com/layers/pytorch/p
 # script.py
 import verifiers as vf
 from verifiers.tools import calculator
-from verifiers.prompts import SEARCH_FEW_SHOT
+from verifiers.prompts import CALCULATOR_FEW_SHOT
 
 model_name = "Qwen/Qwen2.5-7B-Instruct"
 model, tokenizer = vf.get_model_and_tokenizer(model_name)
 
 vf_env = vf.ToolEnv(
     dataset="gsm8k",
-    few_shot=SEARCH_FEW_SHOT[0],
+    few_shot=CALCULATOR_FEW_SHOT[0],
     tools=[calculator],
     max_steps=3
 )

--- a/verifiers/prompts/few_shots.py
+++ b/verifiers/prompts/few_shots.py
@@ -244,9 +244,7 @@ CALCULATOR_FEW_SHOT = [
                 reasoning="Together they have 48 marbles:\n- Tom: 12 marbles\n- Janet: 36 marbles (3 times Tom's)\n- Total: 48 marbles",
                 answer="48 marbles"
             )
-        }
-    ],
-    [
+        },
         {
             'role': 'user',
             'content': 'Samantha is baking cookies. Each batch requires 2.5 cups of flour. If she has 10 cups of flour, how many complete batches can she make?'


### PR DESCRIPTION
Otherwise it will keep calling the wrong tool and keep getting parsing errors...

Also, I think we should merge the trajectories into a single list in few_shots.py, as this aligns with how vLLM processes few-shot examples.







