### PR TITLE
added support for data-dependent system prompts

### DIFF
--- a/verifiers/utils/data_utils.py
+++ b/verifiers/utils/data_utils.py
@@ -1,6 +1,6 @@
 import random
 import json
-from typing import List, Dict
+from typing import List, Dict, Callable
 
 from datasets import Dataset, load_dataset # type: ignore
 
@@ -23,10 +23,10 @@ def extract_boxed_answer(text: str) -> str | None:
     # Find the content between the braces
     content_start = boxed_start + 7  # len('\\boxed{')
     closing_brace = find_matching_brace(text, content_start)
-    
+
     if closing_brace == -1:
         return text
-    
+
     return text[content_start:closing_brace]
 
 def extract_hash_answer(text: str) -> str | None:
@@ -46,41 +46,50 @@ def format_prompt(prompt: str,
     messages.append({"role": "user", "content": prompt})
     return messages
 
-def preprocess_dataset(dataset_name: str = "gsm8k", 
+def preprocess_dataset(dataset_name: str = "gsm8k",
                        split: str = "train",
                        system_prompt: str | None = None,
                        few_shot: List[Dict[str, str]] | None = None,
-                       fewshot_prob: float = 1.0) -> Dataset:
+                       fewshot_prob: float = 1.0,
+                       system_prompt_fn: Callable[[str], str] | None = None,
+                       system_prompt_column: str | None = None) -> Dataset:
+
+    def get_system_prompt(x):
+        if (system_prompt_fn is not None and system_prompt_column is not None and
+                system_prompt_column in x and x[system_prompt_column] is not None):
+            return system_prompt_fn(x[system_prompt_column])
+        return system_prompt
+
     if dataset_name == "gsm8k":
         dataset: Dataset = load_dataset("openai/gsm8k", "main")[split] # type: ignore
         dataset = dataset.map(lambda x: {
-            "prompt": format_prompt(x["question"], system_prompt, few_shot, fewshot_prob),
+            "prompt": format_prompt(x["question"], get_system_prompt(x), few_shot, fewshot_prob),
             "answer": extract_hash_answer(x["answer"])
         })
         return dataset
     elif dataset_name == "math":
         dataset: Dataset = load_dataset("chiayewken/competition_math")[split] # type: ignore
         dataset = dataset.map(lambda x: {
-            "prompt": format_prompt(x["problem"], system_prompt, few_shot, fewshot_prob),
+            "prompt": format_prompt(x["problem"], get_system_prompt(x), few_shot, fewshot_prob),
             "answer": extract_boxed_answer(x["solution"])
         })
         return dataset
     elif dataset_name == "openbookqa":
         dataset: Dataset = load_dataset("allenai/openbookqa", "main")[split] # type: ignore
-        
+
         def format_question(example):
             choices_texts = example['choices']['text']
             choices_labels = example['choices']['label']
-            
+
             formatted_choices = []
             for i in range(len(choices_labels)):
                 formatted_choices.append(f"{choices_labels[i]}. {choices_texts[i]}")
-            
+
             question = f"Question: {example['question_stem']}\n\nChoices:\n" + "\n".join(formatted_choices)
             return question
-        
+
         dataset = dataset.map(lambda x: {
-            "prompt": format_prompt(format_question(x), str(system_prompt) + "\n\nReturn only the letter of the correct answer.", few_shot, fewshot_prob),
+            "prompt": format_prompt(format_question(x), str(get_system_prompt(x)) + "\n\nReturn only the letter of the correct answer.", few_shot, fewshot_prob),
             "answer": x["answerKey"]
         })
         return dataset


### PR DESCRIPTION
Hello, was thinking of some experiments and thought it would be helpful to have an option to change the system prompt depending on a particular column of the input. Implemented as an optional callable function + an optional dataset column name passed to preprocess_dataset so the system prompt can be arbitrary transforms of a field of the input dataset. The changes don't break existing uses.

Example uses could be multi-task RL for combined datasets or system-prompt-conditioned reasoning effort/length training.