### PR TITLE
🧹 Small GRPOEnvTrainer refactor to remove redundant process slice and tidy

### DIFF
--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -96,11 +96,11 @@ class MultiTurnEnv(Environment):
 
     @abstractmethod
     def is_completed(self, messages: List[Dict[str, str]], **kwargs: Any) -> bool:
-        pass
+        raise NotImplementedError("is_completed method must be implemented in subclasses")
 
     @abstractmethod
     def env_response(self, messages: List[Dict[str, str]], **kwargs: Any) -> Dict[str, str]:
-        pass
+        raise NotImplementedError("env_response method must be implemented in subclasses")
 
     def step(self,
              states: List[Dict[str, Any]],


### PR DESCRIPTION
My personal `verifiers` fork implements token level advantage (https://arxiv.org/abs/2505.16826), but thought I'd cut a commit out from the fork that has a universally applicable tidy up! 

I'm also keen to understand more generally if `verifiers` is open to contributions in other areas.