### PR TITLE
Various fixes to allow installing with pip install git+https://github.com/willccbb/verifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,10 @@ all = [
 [project.scripts]
 vf-vllm = "verifiers.inference.vllm_server:cli_main"
 
-[tool.setuptools]
-packages = ["verifiers"]
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["verifiers*"]
+exclude = []
 
 [build-system]
 requires = ["setuptools>=68.0"]

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -17,7 +17,6 @@ from .envs.singleturn_env import SingleTurnEnv
 
 from .envs.codemath_env import CodeMathEnv
 from .envs.doublecheck_env import DoubleCheckEnv
-from .envs.reasoninggym_env import ReasoningGymEnv
 from .envs.tool_env import ToolEnv
 from .envs.smola_tool_env import SmolaToolEnv
 
@@ -46,7 +45,6 @@ __all__ = [
     "SingleTurnEnv",
     "CodeMathEnv",
     "DoubleCheckEnv",
-    "ReasoningGymEnv",
     "ToolEnv",
     "SmolaToolEnv",
     "GRPOTrainer",
@@ -63,3 +61,8 @@ __all__ = [
     "setup_logging",
     "print_prompt_completions_sample",
 ]
+try:
+    from .envs.reasoninggym_env import ReasoningGymEnv
+    __all__.append("ReasoningGymEnv")
+except ImportError:
+    print("Package reasoning_gym not found, ReasoningGymEnv will not be available.")

--- a/verifiers/envs/__init__.py
+++ b/verifiers/envs/__init__.py
@@ -5,7 +5,6 @@ from .singleturn_env import SingleTurnEnv
 
 from .codemath_env import CodeMathEnv
 from .doublecheck_env import DoubleCheckEnv
-from .reasoninggym_env import ReasoningGymEnv
 from .tool_env import ToolEnv
 from .smola_tool_env import SmolaToolEnv
 
@@ -15,7 +14,12 @@ __all__ = [
     'SingleTurnEnv',
     'CodeMathEnv',
     'DoubleCheckEnv',
-    'ReasoningGymEnv',
     'ToolEnv',
     'SmolaToolEnv',
 ]
+
+try:
+    from .reasoninggym_env import ReasoningGymEnv
+    __all__.append('ReasoningGymEnv')
+except ImportError:
+    pass

--- a/verifiers/rubrics/judge_rubric.py
+++ b/verifiers/rubrics/judge_rubric.py
@@ -26,12 +26,14 @@ Respond either "yes" or "no" only."""
 
 class JudgeRubric(Rubric):
     def __init__(self,
-                 judge_client: OpenAI = OpenAI(),
+                 judge_client: OpenAI | None = None,
                  judge_model: str = "gpt-4.1-nano",
                  judge_prompt: str = DEFAULT_JUDGE_PROMPT,
                  parser: Parser = Parser(),
                  **kwargs):
         super().__init__(**kwargs)
+        if judge_client is None:
+            judge_client = OpenAI()
         self.judge_client = judge_client
         self.judge_model = judge_model
         self.judge_prompt = judge_prompt


### PR DESCRIPTION
Hello, when I attempt to install the package via `pip install git+https://github.com/willccbb/verifiers`, and then open up a python shell and run `import verifiers`, I get the following error:
```
>>> import verifiers
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/root/base64decoding/.venv/lib/python3.11/site-packages/verifiers/__init__.py", line 7, in <module>
    from .parsers.parser import Parser
ModuleNotFoundError: No module named 'verifiers.parsers'
```
I fix this by including the submodules using the include pattern `verifiers*`, following the example from [here](https://setuptools.pypa.io/en/latest/userguide/quickstart.html).

After fixing this, attempting to `import verifiers` gave me this issue:
```
File "/root/base64decoding/.venv/lib/python3.11/site-packages/verifiers/rubrics/judge_rubric.py", line 29, in JudgeRubric
judge_client: OpenAI = OpenAI(),
^^^^^^^^
File "/root/base64decoding/.venv/lib/python3.11/site-packages/openai/_client.py", line 126, in init
raise OpenAIError(
openai.OpenAIError: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable
```

Seems like this is related to how Python treats default arguments, and it will attempt to create a single OpenAI client instance at import-time because of this, which will fail without the OPENAI_API_KEY environment variable set. This isn’t ideal if people don’t want to use the OpenAI API at all.

> Python’s default arguments are evaluated once when the function is defined, not each time the function is called (like it is in say, Ruby). This means that if you use a mutable default argument and mutate it, you will and have mutated that object for all future calls to the function as well.
(from https://docs.python-guide.org/writing/gotchas/)

I also notice there are lists as default arguments in the rubric classes - they seem to also exhibit the same issue. If I create two rubrics and add a reward func to one of them, the second rubric gets the same reward func, because both point to the default arg list that gets created at import time.

```
Python 3.11.13 (main, Jun  4 2025, 17:37:17) [Clang 20.1.4 ] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import verifiers as vf
INFO 06-05 05:15:28 [importing.py:53] Triton module has been replaced with a placeholder.
INFO 06-05 05:15:29 [__init__.py:239] Automatically detected platform cuda.
Package reasoning_gym not found, ReasoningGymEnv will not be available.
>>> r1 = vf.Rubric()
>>> r2 = vf.Rubric()
>>> f = lambda x: 1.0
>>> r1.add_reward_func(f)
>>> r2.reward_funcs
[<function <lambda> at 0x7fe66498ec00>]
```

This is probably present in a bunch of places, so just flagging it.

Additionally, I added an import guard against the reasoning env in the case when reasoning_gym isn’t installed with a print statement to notify the user. 
After all these changes, I am able to install the package using pip install and open up a shell and `import verifiers` successfully.