### PR TITLE
Fix: Change SmolaAgents to SmolAgents in comments and docs (#130)

### DIFF
--- a/docs/source/environments.md
+++ b/docs/source/environments.md
@@ -8,7 +8,7 @@ Environments are the orchestration layer of the verifiers framework. They manage
 Environment (base class)
 ├── SingleTurnEnv     # One-shot Q&A tasks
 ├── ToolEnv           # Tool-augmented reasoning  
-├── SmolaToolEnv      # SmolaAgents integration
+├── SmolaToolEnv      # SmolAgents integration
 ├── DoubleCheckEnv    # Multi-stage verification
 ├── TextArenaEnv      # Game environments
 ├── ReasoningGymEnv   # Reasoning benchmarks
@@ -119,9 +119,9 @@ vf_env = vf.ToolEnv(
 - Reasoning alone is insufficient  
 - Examples: Complex math, data analysis, code execution
 
-## SmolaToolEnv: SmolaAgents Integration
+## SmolaToolEnv: SmolAgents Integration
 
-Advanced tool integration using SmolaAgents:
+Advanced tool integration using SmolAgents:
 
 ```python
 import verifiers as vf
@@ -151,7 +151,7 @@ vf_env = SmolaToolEnv(
 
 **Use SmolaToolEnv when:**
 - Need advanced tool capabilities
-- Want SmolaAgents ecosystem integration
+- Want SmolAgents ecosystem integration
 - Examples: Complex scientific computation, multi-step tool workflows
 
 ## DoubleCheckEnv: Self-Verification

--- a/docs/source/examples.md
+++ b/docs/source/examples.md
@@ -116,9 +116,9 @@ trainer = vf.GRPOTrainer(
 trainer.train()
 ```
 
-## SmolaAgents Integration with SmolaToolEnv
+## SmolAgents Integration with SmolaToolEnv
 
-Using SmolaAgents for advanced tool integration:
+Using SmolAgents for advanced tool integration:
 
 ```python
 import verifiers as vf
@@ -136,7 +136,7 @@ dataset = vf.load_example_dataset("math", "train", n=6000)
 eval_aime24 = vf.load_example_dataset("aime2024", n=30)
 eval_aime25 = vf.load_example_dataset("aime2025", n=30)
 
-# Use SmolaAgents' PythonInterpreterTool with custom calculator
+# Use SmolAgents' PythonInterpreterTool with custom calculator
 python_tool = PythonInterpreterTool(
     authorized_imports=["math", "sympy", "numpy"]
 )

--- a/verifiers/envs/smola_tool_env.py
+++ b/verifiers/envs/smola_tool_env.py
@@ -92,7 +92,7 @@ class SmolaToolEnv(MultiTurnEnv):
             return False
 
     def call_tool(self, tool_json: str, **kwargs: Any) -> str:
-        """Call a SmolaAgents Tool object based on JSON command."""
+        """Call a SmolAgents Tool object based on JSON command."""
         try:
             command = json.loads(tool_json)
             if not isinstance(command, dict):

--- a/verifiers/examples/smola_math_tools.py
+++ b/verifiers/examples/smola_math_tools.py
@@ -13,7 +13,7 @@ except ImportError:
     raise ImportError("Please install smolagents to use SmolAgents tools.")
 
 """
-Multi-GPU training (single node, 4 training + 4 inference) using SmolaAgents tools
+Multi-GPU training (single node, 4 training + 4 inference) using SmolAgents tools
 
 CUDA_VISIBLE_DEVICES=0,1,2,3 python verifiers/inference/vllm_server.py \
     --model 'Qwen/Qwen2.5-7B-Instruct' \
@@ -34,7 +34,7 @@ eval_aime24 = load_example_dataset("aime2024", n=30)
 eval_aime25 = load_example_dataset("aime2025", n=30)
 eval_dataset = concatenate_datasets([eval_aime24, eval_aime25]).shuffle(seed=0)
 
-# Use SmolaAgents' PythonInterpreterTool as a replacement for the python tool
+# Use SmolAgents' PythonInterpreterTool as a replacement for the python tool
 python_tool = PythonInterpreterTool(
     authorized_imports=["math", "sympy", "numpy"]
 )

--- a/verifiers/prompts/few_shots.py
+++ b/verifiers/prompts/few_shots.py
@@ -279,7 +279,7 @@ CALCULATOR_FEW_SHOT = [
 ]
 
 """
-Few shot examples for SmolaAgents tool-based assistants.
+Few shot examples for SmolAgents tool-based assistants.
 """
 
 CALCULATOR_SMOLA_FEW_SHOTS = [

--- a/verifiers/prompts/system_prompts.py
+++ b/verifiers/prompts/system_prompts.py
@@ -41,7 +41,7 @@ Do not make up tools or arguments that aren't listed.
 """
 
 """
-Templates for SmolaAgents-style tool prompts.
+Templates for SmolAgents-style tool prompts.
 """
 
 DEFAULT_SMOLA_PROMPT_TEMPLATE = """You are an intelligent assistant designed to solve problems that require careful reasoning.

--- a/verifiers/tools/__init__.py
+++ b/verifiers/tools/__init__.py
@@ -3,7 +3,7 @@ from .calculator import calculator
 from .search import search
 from .python import python
 
-# Import SmolaAgents tools when available
+# Import SmolAgents tools when available
 try:
     from .smolagents import CalculatorTool
     __all__ = ["ask", "calculator", "search", "python", "CalculatorTool"]


### PR DESCRIPTION
  ## Description
  Minimal fix that only corrects the spelling of "SmolaAgents" to "SmolAgents" in comments and documentation.

  ## Changes
  - Fixed 13 instances of "SmolaAgents" → "SmolAgents" across 7 files
  - Only changes comments and documentation text
  - Preserves all class names (e.g., SmolaToolEnv) and file names (e.g., smola_tool_env.py)

  ## Rationale
  This assumes "Smola" is intentionally short for "SmolAgents" and only the full spelling needed correction.

  ## Related Issue
  Fixes #130