### PR TITLE
Fix Rubric and SingleTurnEnv argument examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ We aim to include support for additional trainer backends in the future, and are
 import verifiers as vf
 parser = vf.XMLParser(['think', 'answer']) # <think>...</think>\n<answer>...</answer>
 rubric = vf.Rubric(
-	your_custom_reward_func, # def func(prompt, completion, answer, **kwargs)
-	parser.get_format_reward_func(),
-weights=[1.0, 0.2])
+	funcs=[your_custom_reward_func, # def func(prompt, completion, answer, **kwargs)
+	parser.get_format_reward_func()],
+	weights=[1.0, 0.2])
 vf_env = vf.SingleTurnEnv(
 	dataset=..., # hf Dataset with 'question' + 'answer' columns
 	system_prompt=f"... Respond in the following format: {parser.get_format_str()}",
-	rubric
+	rubric=rubric
 )
 ```
 


### PR DESCRIPTION
Hi, I tried the example in the README but there were some problems with the arguments.

For
```
rubric = vf.Rubric(
	your_custom_reward_func,
  parser.get_format_reward_func(),
  weights=[1.0, 0.2])
```
I get
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
[/tmp/ipython-input-33-1009807220.py](https://localhost:8080/#) in <cell line: 0>()
----> 1 rubric = vf.Rubric(
      2         your_custom_reward_func,
      3   parser.get_format_reward_func(),
      4   weights=[1.0, 0.2])

TypeError: Rubric.__init__() got multiple values for argument 'weights'
```
so I think we can instead do
```
rubric = vf.Rubric(
	funcs=[your_custom_reward_func,
	      parser.get_format_reward_func()],
  weights=[1.0, 0.2])
```

```
vf_env = vf.SingleTurnEnv(
	dataset=dataset,
	system_prompt=f"... Respond in the following format: {parser.get_format_str()}",
	rubric
)
```
gives SyntaxError: positional argument follows keyword argument
so we could do
```
vf_env = vf.SingleTurnEnv(
	dataset=dataset,
	system_prompt=f"... Respond in the following format: {parser.get_format_str()}",
	rubric=rubric
)
```