### PR TITLE
fix: correctly access arguments in reverse_text example

### DIFF
--- a/verifiers/examples/eval/reverse_text.py
+++ b/verifiers/examples/eval/reverse_text.py
@@ -90,4 +90,4 @@ if __name__ == "__main__":
     argparser.add_argument("--max-tokens", "-t", type=int, default=4096)
     argparser.add_argument("--save-dataset", "-s", action="store_true", default=False)
     args = argparser.parse_args()
-    main(args.api, args.num_examples, args.max_tokens, args.save_dataset)
+    main(args.api, args.num_examples, args.max_tokens, args.rollouts_per_example, args.save_dataset)

--- a/verifiers/examples/eval/reverse_text.py
+++ b/verifiers/examples/eval/reverse_text.py
@@ -90,4 +90,4 @@ if __name__ == "__main__":
     argparser.add_argument("--max-tokens", "-t", type=int, default=4096)
     argparser.add_argument("--save-dataset", "-s", action="store_true", default=False)
     args = argparser.parse_args()
-    main(args.api, args.num_samples, args.max_tokens, args.save_dataset)
+    main(args.api, args.num_examples, args.max_tokens, args.save_dataset)


### PR DESCRIPTION
## Description
Fixes two simple typos in the reverse_text example.

Great repo!

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
N/A

### Test Coverage
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes
N/A