### PR TITLE
Remove repeated messages that spam the stdout when rollouts are slow.

### DIFF
--- a/verifiers/trainers/grpo_trainer.py
+++ b/verifiers/trainers/grpo_trainer.py
@@ -766,11 +766,14 @@ class GRPOTrainer(Trainer):
         is_generating = is_generating_list[0]
 
         # All processes wait if generation is happening
+        is_printed = False
         while is_generating:
             time.sleep(0.5)
-            self.logger.info(
-                "Waiting for background batch generation to complete before weight syncing."
-            )
+            if not is_printed:
+                self.logger.info(
+                    "Waiting for background batch generation to complete before weight syncing."
+                )
+                is_printed = True
 
             # Check again and broadcast
             if self.accelerator.is_main_process:


### PR DESCRIPTION
## Description
When rollouts are lagging behind the trainer, the console gets spanned with notification messages. This change prints only one notification and suppresses subsequent ones.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass
- [ ] New tests have been added to cover the changes
- [x] Tests have been run locally with `python -m pytest tests/`

### Test Coverage
<!-- If applicable, mention the test coverage for new code -->
- Current coverage: ___%
- Coverage after changes: ___%

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->