### PR TITLE
Add rich as default dependency for eval script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "datasets",
     "pydantic>=2.11.7",
     "jinja2>=3.1.6",
+    "rich",
 ]
 
 [project.optional-dependencies]
@@ -46,7 +47,6 @@ all = [
     "deepspeed",
     "peft",
     "wandb",
-    "rich",
     "trl>=0.17.0",
     "vllm>=0.9.2",
     "liger-kernel>=0.5.10",
@@ -81,7 +81,6 @@ train = [
     "requests",
     "peft",
     "wandb",
-    "rich",
     "trl>=0.17.0",
     "vllm>=0.9.2",
     "liger-kernel>=0.5.10",


### PR DESCRIPTION
## Description

The README says to install verifiers with 

```
uv add verifiers
```

for evaluation, but this doesn't work because the evaluation script depends on `rich`, which is not a default dependency. This PR makes it a default dependency.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass
- [ ] New tests have been added to cover the changes
- [x] Tests have been run locally with `python -m pytest tests/`