### PR TITLE
Fix for JudgeRubric not using async

### DIFF
--- a/verifiers/rubrics/rubric.py
+++ b/verifiers/rubrics/rubric.py
@@ -1,4 +1,5 @@
 import asyncio
+from asyncio.coroutines import iscoroutinefunction
 import inspect
 import logging
 
@@ -98,14 +99,18 @@ class Rubric:
         merged = {**common, **kwargs}
         if any(p.kind == p.VAR_KEYWORD for p in sig.parameters.values()):
             try:
-                ans = await func(**merged)
+                ans = func(**merged)
+                if inspect.iscoroutinefunction(func):
+                    ans = await ans
             except Exception as e:
                 self.logger.error(f"Error calling reward function {func.__name__}: {e}")
                 ans = 0.0
         else:
             allowed = {k: v for k, v in merged.items() if k in sig.parameters}
             try:
-                ans = await func(**allowed)
+                ans = func(**allowed)
+                if inspect.iscoroutinefunction(func):
+                    ans = await ans
             except Exception as e:
                 self.logger.error(f"Error calling reward function {func.__name__}: {e}")
                 ans = 0.0

--- a/verifiers/rubrics/rubric.py
+++ b/verifiers/rubrics/rubric.py
@@ -98,14 +98,14 @@ class Rubric:
         merged = {**common, **kwargs}
         if any(p.kind == p.VAR_KEYWORD for p in sig.parameters.values()):
             try:
-                ans = func(**merged)
+                ans = await func(**merged)
             except Exception as e:
                 self.logger.error(f"Error calling reward function {func.__name__}: {e}")
                 ans = 0.0
         else:
             allowed = {k: v for k, v in merged.items() if k in sig.parameters}
             try:
-                ans = func(**allowed)
+                ans = await func(**allowed)
             except Exception as e:
                 self.logger.error(f"Error calling reward function {func.__name__}: {e}")
                 ans = 0.0

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -1,5 +1,6 @@
 from typing import (
     Any,
+    Awaitable,
     Callable,
     Literal,
 )
@@ -31,7 +32,7 @@ Messages = str | list[ChatMessage]
 Info = dict[str, Any]
 State = dict[str, Any]
 SamplingArgs = dict[str, Any]
-RewardFunc = Callable[..., float]
+RewardFunc = Callable[..., float | Awaitable[float]]
 
 # oai tools
 JsonPrimitive = Literal["string", "number", "integer", "boolean", "array", "object"]


### PR DESCRIPTION
## Description
Adds support for async RewardFuncs and async client usage with JudgeRubric. It only awaits if the RewardFunc is an async def function.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass
- [ ] New tests have been added to cover the changes
- [x] Tests have been run locally with `python -m pytest tests/`

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->