### PR TITLE
vf-tui parsing crashes when tool_calls contains JSON strings instead of dicts

### DIFF
--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -142,10 +142,24 @@ def format_prompt_or_completion(prompt_or_completion) -> str:
             else:
                 lines.append(f"[dim][b]{role}:[/b] {content}[/dim]")
             if "tool_calls" in msg and msg["tool_calls"]:
-                for tool_call in msg["tool_calls"]:
-                    lines.append(
-                        f"[b]tool call:[/b] {tool_call['function']['name']}\n{tool_call['function']['arguments']}"
-                    )
+                tool_calls_data = msg["tool_calls"]
+                if isinstance(tool_calls_data, list) and len(tool_calls_data) > 0 and isinstance(tool_calls_data[0], str):
+                    import json
+                    parsed_tool_calls = []
+                    for tc_str in tool_calls_data:
+                        try:
+                            parsed_tool_calls.append(json.loads(tc_str))
+                        except (json.JSONDecodeError, TypeError):
+                            parsed_tool_calls.append(tc_str)
+                    tool_calls_data = parsed_tool_calls
+                
+                for tool_call in tool_calls_data:
+                    if isinstance(tool_call, dict) and 'function' in tool_call:
+                        lines.append(
+                            f"[b]tool call:[/b] {tool_call['function']['name']}\n{tool_call['function']['arguments']}"
+                        )
+                    elif isinstance(tool_call, str):
+                        lines.append(f"[b]tool call:[/b] {tool_call}")
         return "\n\n".join(lines)
     return str(prompt_or_completion)
 


### PR DESCRIPTION
## Description
 Fixes the vf-tui viewer to properly handle tool_calls when they are stored as JSON strings instead of dictionary objects. This issue was preventing vf-tui from displaying tool calls for certain environments that serialize tool_calls as JSON strings in their output. I encountered this issue when testing viewing results on the [ARC-AGI 1 + 2 with tool calling environment](https://github.com/nancyjlau/prime-environments/tree/arc-agi-toolenv), more info about runs [at my env PR](https://github.com/PrimeIntellect-ai/prime-environments/pull/43)

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass
- [x] Tests have been run locally with `python -m pytest tests/`

### Test Coverage
<!-- If applicable, mention the test coverage for new code -->
- Current coverage: 100%
- Coverage after changes: 100%

## Additional Notes
<img width="1376" height="825" alt="Screenshot 2025-08-26 at 6 17 33 PM" src="https://github.com/user-attachments/assets/9502979d-d68a-4193-8f85-dae64dede73a" />
<img width="1509" height="309" alt="image" src="https://github.com/user-attachments/assets/fc33a712-090c-4d38-ae36-0885f2dcd44b" />

## After fix
<img width="1257" height="893" alt="image" src="https://github.com/user-attachments/assets/928082e7-c499-47d0-b9b5-4e17883369dd" />

<!-- Add any additional notes, screenshots, or context about the PR here -->