### PR TITLE
fix gsm8k environment parser

### DIFF
--- a/environments/gsm8k/gsm8k.py
+++ b/environments/gsm8k/gsm8k.py
@@ -31,6 +31,7 @@ def load_environment(
     rubric = vf.Rubric(
         funcs=[correct_answer_reward_func, parser.get_format_reward_func()],
         weights=[1.0, 0.0],
+        parser=parser,
     )
 
     vf_env = vf.SingleTurnEnv(


### PR DESCRIPTION
## Description
currently the gsm8k environment does not use the parser configured (extract_boxed_answer), so all rollouts get a 0 reward.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass
- [ ] New tests have been added to cover the changes
- [x] Tests have been run locally with `python -m pytest tests/`

### Test Coverage
<!-- If applicable, mention the test coverage for new code -->
- Current coverage: ___%
- Coverage after changes: ___%

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->