### PR TITLE
docs(rubric): add documentation for passing class objects to reward functions

### DIFF
--- a/docs/source/components.md
+++ b/docs/source/components.md
@@ -114,6 +114,117 @@ tool_rubric.reward_weights[0] = -0.1   # penalize excessive tool calls
 tool_rubric.reward_weights[2] = 0.2    # reward using search_web specifically
 ```
 
+### Rubric.class_objects: Passing Objects to Reward Functions
+
+The `class_objects` pattern allows you to pass class instances or other objects directly to your reward functions. This is especially useful when your reward functions need access to parsers, clients, or other stateful objects.
+
+**How it works:**
+
+When a rubric calls a reward function, it automatically merges `self.class_objects` with the standard arguments (`prompt`, `completion`, `answer`, `state`, etc.). Your reward functions can then accept these objects as parameters.
+
+**Basic Example:**
+
+```python
+class CustomRubric(vf.Rubric):
+    def __init__(self, api_client, custom_parser, **kwargs):
+        super().__init__(**kwargs)
+        self.api_client = api_client
+        self.custom_parser = custom_parser
+        
+        # Make objects available to reward functions
+        self.class_objects = {
+            "parser": self.parser,           # Standard parser (automatically added)
+            "api_client": self.api_client,   # Custom API client
+            "custom_parser": self.custom_parser,  # Additional parser
+        }
+        
+        # Add reward functions that use these objects
+        self.reward_funcs = [self.api_based_reward, self.parsing_reward]
+
+    def api_based_reward(self, completion, answer, api_client, **kwargs):
+        """Reward function that uses the API client."""
+        # Extract answer from completion
+        extracted = self.parser.parse_answer(completion)
+        
+        # Use API client to validate answer
+        validation_result = api_client.validate(extracted, answer)
+        return 1.0 if validation_result.is_correct else 0.0
+    
+    def parsing_reward(self, completion, custom_parser, **kwargs):
+        """Reward function that uses a custom parser."""
+        # Use the custom parser passed via class_objects
+        parsed_data = custom_parser.parse(completion)
+        return 1.0 if parsed_data.is_well_formed else 0.0
+```
+
+**Real-world Example: JudgeRubric**
+
+The built-in `JudgeRubric` demonstrates this pattern:
+
+```python
+class JudgeRubric(vf.Rubric):
+    def __init__(self, judge_client=None, judge_model="gpt-4o-mini", **kwargs):
+        super().__init__(**kwargs)
+        self.judge_client = judge_client or AsyncOpenAI()
+        self.judge_model = judge_model
+        
+        # Expose objects to reward functions
+        self.class_objects = {
+            "parser": self.parser,
+            "judge": self.judge,  # The judge method itself
+            "judge_client": self.judge_client,
+            "judge_model": self.judge_model,
+        }
+
+    async def judge(self, prompt, completion, answer, state, **kwargs):
+        """Judge method that can be called by reward functions."""
+        # Implementation uses self.judge_client to evaluate responses
+        ...
+```
+
+**Usage in Reward Functions:**
+
+```python
+# Your reward function can access any object from class_objects
+def quality_reward(completion, answer, judge, **kwargs):
+    """Use the judge method to evaluate response quality."""
+    judgment = await judge(prompt, completion, answer, state)
+    return 1.0 if "excellent" in judgment.lower() else 0.5
+
+def format_reward(completion, parser, **kwargs):
+    """Use the parser to check formatting."""
+    parsed = parser.parse_answer(completion)
+    return 1.0 if parsed else 0.0
+```
+
+**Best Practices:**
+
+1. **Include all necessary objects**: Add any parsers, clients, or helpers your reward functions need
+2. **Use descriptive names**: Choose clear names for your class_objects keys
+3. **Document dependencies**: Make it clear which reward functions use which objects
+4. **Handle missing objects gracefully**: Use `**kwargs` and check for object availability
+
+**Advanced Pattern: Shared State**
+
+```python
+class StatefulRubric(vf.Rubric):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.shared_state = {"call_count": 0}
+        
+        self.class_objects = {
+            "parser": self.parser,
+            "shared_state": self.shared_state,
+        }
+        
+        self.reward_funcs = [self.counting_reward]
+    
+    def counting_reward(self, completion, shared_state, **kwargs):
+        """Track calls across reward function invocations."""
+        shared_state["call_count"] += 1
+        return 1.0 if shared_state["call_count"] <= 5 else 0.5
+```
+
 ## Tools
 
 Verifiers provides native support for tool calling, leveraging models' built-in function calling capabilities.


### PR DESCRIPTION
- Explain how to use `class_objects` to pass instances and stateful objects to reward functions
- Provide basic example demonstrating custom rubric with API client and parsers
- Describe real-world usage with built-in JudgeRubric example
- Show example reward functions accessing objects like judge and parser
- List best practices for managing class_objects and reward function dependencies
- Introduce advanced pattern for shared state across reward functions with StatefulRubric example

Based on the changes I made to add the `Rubric.class_objects` pattern documentation, here's the completed PR description:

## Description

Added comprehensive documentation for the `Rubric.class_objects` pattern to the components guide. This pattern allows developers to pass class instances, parsers, clients, and other stateful objects directly to reward functions within custom rubrics. The documentation includes practical examples, best practices, and real-world usage patterns based on the existing `JudgeRubric` implementation.

## Type of Change

- [x] Documentation update

## Testing

- [x] All existing tests pass
- [ ] New tests have been added to cover the changes (N/A - documentation only)
- [x] Tests have been run locally with `python -m pytest tests/` (no test failures)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

The new documentation section includes:

- **Core concept explanation**: How `class_objects` are automatically merged with standard reward function arguments
- **Basic example**: Complete `CustomRubric` class demonstrating the pattern
- **Real-world reference**: How `JudgeRubric` implements this pattern in practice
- **Usage examples**: Reward functions that accept objects like parsers, API clients, and judges
- **Best practices**: Guidelines for naming, error handling, and documentation
- **Advanced pattern**: Shared state tracking across reward function calls

This addresses issue #265 by providing clear guidance on an important but previously undocumented rubric pattern that enables more sophisticated reward function implementations.