### PR TITLE
Fix `max_concurrent_requests` in eval script and also use for rollout scoring

### DIFF
--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -430,6 +430,7 @@ class Environment(ABC):
                 states=results.state,
                 tasks=results.task,
                 infos=results.info,
+                max_concurrent=max_concurrent,
                 apply_weights=True,
             )
             results.reward = rollout_scores.reward

--- a/verifiers/rubrics/rubric.py
+++ b/verifiers/rubrics/rubric.py
@@ -114,6 +114,18 @@ class Rubric:
                 ans = 0.0
         return ans
 
+    async def score_rollout_with_semaphore(
+        self,
+        semaphore: asyncio.Semaphore,
+        *args,
+        **kwargs,
+    ) -> RolloutScore:
+        """
+        Score a rollout with a semaphore.
+        """
+        async with semaphore:
+            return await self.score_rollout(*args, **kwargs)
+
     async def score_rollout(
         self,
         prompt: Messages,
@@ -178,6 +190,7 @@ class Rubric:
         states: list[State],
         tasks: list[str],
         infos: list[Info],
+        max_concurrent: int = -1,
         **kwargs,
     ) -> RolloutScores:
         """
@@ -193,10 +206,18 @@ class Rubric:
         """
         from tqdm.asyncio import tqdm_asyncio
 
-        rollout_tasks = [
-            self.score_rollout(*pcasti, **kwargs)
-            for pcasti in zip(prompts, completions, answers, states, tasks, infos)
-        ]
+        if max_concurrent > 0:
+            semaphore = asyncio.Semaphore(max_concurrent)
+            rollout_tasks = [
+                self.score_rollout_with_semaphore(semaphore, *pcasti, **kwargs)
+                for pcasti in zip(prompts, completions, answers, states, tasks, infos)
+            ]
+        else:
+            rollout_tasks = [
+                self.score_rollout(*pcasti, **kwargs)
+                for pcasti in zip(prompts, completions, answers, states, tasks, infos)
+            ]
+
         rewards = await tqdm_asyncio.gather(
             *rollout_tasks,
             total=len(prompts),

--- a/verifiers/rubrics/rubric_group.py
+++ b/verifiers/rubrics/rubric_group.py
@@ -46,6 +46,7 @@ class RubricGroup(Rubric):
         states: list[State],
         tasks: list[str],
         infos: list[Info],
+        max_concurrent: int = -1,
         **kwargs,
     ) -> RolloutScores:
         """
@@ -59,7 +60,14 @@ class RubricGroup(Rubric):
         )
         for rubric in self.rubrics:
             rubric_scores = await rubric.score_rollouts(
-                prompts, completions, answers, states, tasks, infos, **kwargs
+                prompts,
+                completions,
+                answers,
+                states,
+                tasks,
+                infos,
+                max_concurrent,
+                **kwargs,
             )
             # aggregate reward (element-wise sum across rubrics)
             if not all_scores.reward:

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -97,7 +97,7 @@ def eval_environment(
         sampling_args=merged_sampling_args,
         num_examples=num_examples,
         rollouts_per_example=rollouts_per_example,
-        max_concurrent_requests=max_concurrent_requests,
+        max_concurrent=max_concurrent_requests,
     )
     logger.info("Evaluation completed successfully")
     logger.info("--- Evaluation ---")


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Previously, the `max_concurrent_requests` argument would only be used to limit the concurrency during rollout generation, not scoring. For more complex scoring systems, like those depending on external resources which can have rate limits, limiting the concurrency during scoring is necessary. This PR implements this.

## Example

I use the `gsm8k` environment and put an artificial delay during scoring to highlight the parallelism that can be achieved by scoring in parallel. In particular, the change made for the below tests is:

```python
  async def correct_answer_reward_func(parser, completion, answer, **kwargs):
      import asyncio

      await asyncio.sleep(1)
      response = parser.parse_answer(completion) or ""
      return 1.0 if response == answer else 0.0
```

No concurrency limitation (run 5 examples, 3 rollouts each) - this finishes in **12s** because everything runs in parallel

```bash
uv run --active vf-eval gsm8k -a '{"use_think": false}'
```

With concurrency limitation (run 5 examples, 3 rollouts each, max concurrency = 1) - this finishes in **60s** because all generation and scoring are running sequential

```bash
uv run --active vf-eval gsm8k -a '{"use_think": false}' -c 1
```


## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass
- [ ] New tests have been added to cover the changes
- [ ] Tests have been run locally with `python -m pytest tests/`

### Test Coverage
<!-- If applicable, mention the test coverage for new code -->
- Current coverage: ___%
- Coverage after changes: ___%

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->