### PR TITLE
Fix log verbosity of third-party packages in eval script

### DIFF
--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -15,6 +15,9 @@ from openai import OpenAI
 import verifiers as vf
 from verifiers.utils.message_utils import messages_to_printable, sanitize_tool_calls
 
+# Setup logger for eval script
+logger = logging.getLogger(__name__)
+
 
 def eval_environment(
     env: str,
@@ -35,9 +38,7 @@ def eval_environment(
     save_to_hf_hub: bool,
     hf_hub_dataset_name: str,
 ):
-    # Setup logger for this function
-    logger = logging.getLogger(__name__)
-
+    logger.setLevel("DEBUG" if verbose else "INFO")
     try:
         endpoints_path_obj = Path(endpoints_path)
         if endpoints_path_obj.is_dir():
@@ -314,15 +315,6 @@ def main():
         help="Name of dataset to save to Hugging Face Hub",
     )
     args = parser.parse_args()
-
-    # Setup logging based on verbose flag
-    log_level = "DEBUG" if args.verbose else "INFO"
-    logging.basicConfig(
-        level=log_level, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-    )
-    logger = logging.getLogger(__name__)
-    logger.info("Starting vf-eval with arguments")
-    logger.debug(f"Parsed arguments: {vars(args)}")
 
     eval_environment(
         env=args.env,


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Running with 

```bash
uv run vf-eval gsm8k -a '{"use_think": false}'
```

## Before

<img width="1059" height="438" alt="Screenshot 2025-09-05 at 3 43 21 PM" src="https://github.com/user-attachments/assets/36e3b3d9-b073-45e6-89e3-4e3e2fc20b9b" />

## After

<img width="1065" height="272" alt="Screenshot 2025-09-05 at 3 42 37 PM" src="https://github.com/user-attachments/assets/48757650-e336-48b7-b598-3afa81ae7020" />

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass
- [ ] New tests have been added to cover the changes
- [ ] Tests have been run locally with `python -m pytest tests/`

### Test Coverage
<!-- If applicable, mention the test coverage for new code -->
- Current coverage: ___%
- Coverage after changes: ___%

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->