### PR TITLE
Option to find last instance of  \boxed{}

### DIFF
--- a/verifiers/utils/data_utils.py
+++ b/verifiers/utils/data_utils.py
@@ -17,7 +17,7 @@ BOXED_SYSTEM_PROMPT = (
 ###############
 
 
-def extract_boxed_answer(text: str) -> str:
+def extract_boxed_answer(text: str, find_last: bool = False) -> str:
     def find_matching_brace(s: str, start: int) -> int:
         count = 1
         i = start
@@ -30,7 +30,10 @@ def extract_boxed_answer(text: str) -> str:
         return i - 1 if count == 0 else -1
 
     # Find \boxed{
-    boxed_start = text.find("\\boxed{")
+    if find_last:
+        boxed_start = text.find("\\boxed{")
+    else:
+        boxed_start = text.rfind("\\boxed{")
     if boxed_start == -1:
         return text
     # Find the content between the braces

--- a/verifiers/utils/data_utils.py
+++ b/verifiers/utils/data_utils.py
@@ -31,9 +31,9 @@ def extract_boxed_answer(text: str, find_last: bool = False) -> str:
 
     # Find \boxed{
     if find_last:
-        boxed_start = text.find("\\boxed{")
-    else:
         boxed_start = text.rfind("\\boxed{")
+    else:
+        boxed_start = text.find("\\boxed{")
     if boxed_start == -1:
         return text
     # Find the content between the braces


### PR DESCRIPTION
## Description
Add a new parameter to `extract_boxed_answer` called `find_last`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
- [x] All existing tests pass
- [ ] New tests have been added to cover the changes
- [x] Tests have been run locally with `python -m pytest tests/`

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes
This doesn't change anything, it just adds a new param which defaults to the old behavior.