### PR TITLE
fix(envs): Async tool call bug in StatefulToolEnv

### DIFF
--- a/verifiers/envs/stateful_tool_env.py
+++ b/verifiers/envs/stateful_tool_env.py
@@ -4,6 +4,7 @@ from typing import Callable
 
 from verifiers.envs.tool_env import ToolEnv
 from verifiers.types import ChatCompletionMessageToolCall, Message, Messages, State
+from verifiers.utils.async_utils import maybe_await
 from verifiers.utils.tool_utils import convert_func_to_oai_tool
 
 
@@ -40,7 +41,7 @@ class StatefulToolEnv(ToolEnv):
         """Call a tool based on JSON command."""
         try:
             tool_func = self.tool_map[tool_name]
-            result = str(tool_func(**tool_args))
+            result = await maybe_await(tool_func, **tool_args)
             return {
                 "role": "tool",
                 "content": str(result),


### PR DESCRIPTION
## Description
Fixed a bug where StatefulToolEnv was not properly awaiting async tool functions, unlike the parent ToolEnv class which uses `maybe_await`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
- [x] All existing tests pass
- [x] Tests have been run locally with `uv run pytest`
- [x] Code follows project style guidelines (ruff check/format passed)

## Changes Made
1. Added missing import for `maybe_await` from `verifiers.utils.async_utils`
2. Updated `call_tool` method to use `await maybe_await(tool_func, **tool_args)` instead of direct synchronous call
3. This ensures consistent async/sync tool support matching the parent ToolEnv implementation

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] Tests pass locally
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.ai/code)