### PR TITLE
Add Claude Code environment for single-shot tasks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "rich",
     "textual",
     "openai-agents>=0.0.7",
+    "claude-code-sdk>=0.0.22",
 ]
 
 [project.optional-dependencies]

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -12,6 +12,7 @@ from .envs.multiturn_env import MultiTurnEnv
 from .envs.singleturn_env import SingleTurnEnv
 from .envs.stateful_tool_env import StatefulToolEnv
 from .envs.tool_env import ToolEnv
+from .envs.claude_code_env import ClaudeCodeEnv
 from .parsers.parser import Parser
 from .parsers.think_parser import ThinkParser
 from .parsers.xml_parser import XMLParser
@@ -76,6 +77,7 @@ __all__ = [
     "SingleTurnEnv",
     "StatefulToolEnv",
     "ToolEnv",
+    "ClaudeCodeEnv",
     "EnvGroup",
     "extract_boxed_answer",
     "extract_hash_answer",

--- a/verifiers/envs/claude_code_env.py
+++ b/verifiers/envs/claude_code_env.py
@@ -1,0 +1,168 @@
+"""
+Claude Code environment for single-shot tasks.
+Multi shot tasks will need to have a different implementation and possible inherit or share functionality with `multiturn_env.py`
+"""
+
+import json
+from typing import Any, Callable
+from claude_code_sdk import query, ClaudeCodeOptions
+from claude_code_sdk.types import (
+    ResultMessage,
+    SystemMessage,
+    AssistantMessage,
+    UserMessage,
+    TextBlock,
+    ToolUseBlock,
+    ToolResultBlock,
+)
+from claude_code_sdk.types import Message as AnthropicMessage
+from verifiers.envs.environment import Environment
+from verifiers.utils.async_utils import maybe_await
+from verifiers.types import Info, Messages, SamplingArgs, State
+
+
+class ClaudeCodeEnv(Environment):
+    def __init__(
+        self,
+        max_turns=-1,
+        tools: list[Callable] | None = None,
+        system_prompt: str | None = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.tools = tools
+        self.max_turns = max_turns
+        self.system_prompt = system_prompt
+
+    async def setup_state(self, state: State, **kwargs) -> State:
+        #   TODO: maybe implement state setup? maybe the claude options?
+        return state
+
+    async def anthropic_to_oai_completion(
+        self, anthropic_msgs: list[AnthropicMessage]
+    ) -> Messages:
+        oai_messages = []
+
+        for msg in anthropic_msgs:
+            if isinstance(msg, UserMessage):
+                # Convert user message content
+                if isinstance(msg.content, str):
+                    oai_messages.append({"role": "user", "content": msg.content})
+                elif isinstance(msg.content, list):
+                    # Handle content blocks in user messages
+                    text_parts = []
+                    for block in msg.content:
+                        if isinstance(block, TextBlock):
+                            text_parts.append(block.text)
+                        elif isinstance(block, ToolResultBlock):
+                            # OpenAI expects tool results in separate messages
+                            oai_messages.append(
+                                {
+                                    "role": "tool",
+                                    "tool_call_id": block.tool_use_id,
+                                    "content": json.dumps(block.content)
+                                    if block.content
+                                    else "",
+                                }
+                            )
+
+                    # Add user text if any
+                    if text_parts:
+                        oai_messages.append(
+                            {"role": "user", "content": "\n".join(text_parts)}
+                        )
+
+            elif isinstance(msg, AssistantMessage):
+                # Convert assistant message content
+                text_parts = []
+                tool_calls = []
+
+                if hasattr(msg, "content") and msg.content:
+                    for block in msg.content:
+                        if isinstance(block, TextBlock):
+                            text_parts.append(block.text)
+                        elif isinstance(block, ToolUseBlock):
+                            tool_calls.append(
+                                {
+                                    "id": block.id,
+                                    "type": "function",
+                                    "function": {
+                                        "name": block.name,
+                                        "arguments": json.dumps(block.input),
+                                    },
+                                }
+                            )
+                        elif isinstance(block, ToolResultBlock):
+                            # Tool results in assistant messages are unusual but handle them
+                            if block.content:
+                                text_parts.append(f"Tool result: {block.content}")
+
+                # Build message with proper typing
+                oai_message: dict[str, Any] = {
+                    "role": "assistant",
+                    "content": "\n".join(text_parts) if text_parts else "",
+                }
+
+                if tool_calls:
+                    oai_message["tool_calls"] = tool_calls
+
+                oai_messages.append(oai_message)
+
+            elif isinstance(msg, SystemMessage):
+                # Skip init and metadata messages, they don't map to OpenAI format
+                continue
+
+            elif isinstance(msg, ResultMessage):
+                # Skip result messages as they contain metadata, not conversation content
+                if msg.result:
+                    oai_message = {"role": "assistant", "content": msg.result}
+                    oai_messages.append(oai_message)
+
+        return oai_messages
+
+    async def rollout(
+        self,
+        client,
+        model: str,
+        prompt: Messages,
+        answer: str = "",
+        task: str = "default",
+        info: Info | None = None,
+        sampling_args: SamplingArgs | None = None,
+        **kwargs,
+    ) -> tuple[Messages, State]:
+        """
+        Run rollout on Claude Code for a given prompt.
+        Returns a tuple of (completion, state).
+        """
+        info = info or {}
+        if isinstance(prompt, str):
+            rollout = prompt
+        else:
+            rollout = str(prompt[-1]["content"]) if "content" in prompt[-1] else ""
+        state = {
+            "prompt": prompt,
+            "completion": [],  # maybe we dont need this
+            "task": task,
+            "info": info,
+            "tools": [],
+            "responses": [],
+            "turn": 0,
+            "mcp_servers": [],
+            "claude_code_options": {"permission_mode": "bypassPermissions"},
+        }
+        state = await maybe_await(self.setup_state, state, **kwargs)
+        options = ClaudeCodeOptions(
+            **state["claude_code_options"], system_prompt=self.system_prompt
+        )
+        messages = list()
+        async for message in query(prompt=rollout, options=options):
+            if isinstance(message, SystemMessage) and message.subtype == "init":
+                state["tools"] = message.data["tools"]
+                state["mcp_servers"] = message.data["mcp_servers"]
+            if isinstance(message, ResultMessage):
+                state["result_msg"] = message.result
+                state["success"] = not message.is_error
+            messages.append(message)
+        oai_messages = await self.anthropic_to_oai_completion(anthropic_msgs=messages)
+        return oai_messages, state


### PR DESCRIPTION
## Description
The added class enables interaction with Claude Code for code-related tasks through a standardized environment interface.


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass
- [ ] New tests have been added to cover the changes
- [x] Tests have been run locally with `uv run pytest`

### Test Coverage
<!-- If applicable, mention the test coverage for new code -->
- Current coverage: ___%
- Coverage after changes: ___%

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
This adds claude code as a harness in a compatible manner such that it can be used in existing environments. Main motivation behind this is that, one can now add more complex, multi step coding/non-coding tasks in environment without having to write many tools used in these agents from scratch.

For example: terminal-bench supports running it across a bunch of existing agents/CLIs: https://github.com/laude-institute/terminal-bench/tree/main/terminal_bench/agents/installed_agents
