### PR TITLE
Add attn_implementation parameter to get_model_and_tokenizer

### DIFF
--- a/verifiers/utils/model_utils.py
+++ b/verifiers/utils/model_utils.py
@@ -101,8 +101,17 @@ def get_tokenizer(model_name: str) -> Any:
 
 
 def get_model_and_tokenizer(
-    model_name: str, use_liger: bool = True, model_kwargs: dict[str, Any] | None = None
+    model_name: str, 
+    use_liger: bool = True, 
+    model_kwargs: dict[str, Any] | None = None,
+    attn_implementation: str | None = None
 ) -> tuple[Any, Any]:
+    # If attn_implementation is provided, override it in model_kwargs
+    if attn_implementation is not None:
+        if model_kwargs is None:
+            model_kwargs = {}
+        model_kwargs["attn_implementation"] = attn_implementation
+    
     model = get_model(model_name, use_liger, model_kwargs)
     tokenizer = get_tokenizer(model_name)
     return model, tokenizer


### PR DESCRIPTION
- Add optional attn_implementation parameter to get_model_and_tokenizer function
- Allows users to override the default flash_attention_2 setting
- Useful for avoiding FlashAttention compatibility issues on certain platforms
- Maintains backward compatibility with existing code

 