### PR TITLE
Add ty pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,16 @@ repos:
       # Run the formatter.
       - id: ruff-format
         args: [--config=pyproject.toml]
+  - repo: local
+    hooks:
+      - id: ty
+        name: ty
+        entry: ty
+        args:
+          - check
+          - --exit-zero
+          - --output-format=concise
+        language: python
+        additional_dependencies:
+          - ty==0.0.1a21
+        types_or: [python, pyi]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,10 @@ filterwarnings = [
 asyncio_mode = "auto"
 norecursedirs = [".git", ".tox", "dist", "build", "*.egg", "__pycache__"]
 
+[tool.ty.rules]
+unresolved-import = "warn"
+unknown-argument = "warn"
+
 [tool.coverage.run]
 source = ["verifiers"]
 omit = [


### PR DESCRIPTION
## Summary
- add a local pre-commit hook that installs ty and runs `ty check` with concise output
- configure ty to downgrade unresolved-import and unknown-argument diagnostics to warnings so pre-commit can surface issues without blocking

## Testing
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68cde0a89870832680558bb34aa342cd